### PR TITLE
chore: Markdown All in One をプロジェクト規定の拡張機能に追加

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,6 @@
 {
   "recommendations": [
-    // https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno
     "denoland.vscode-deno",
-    // https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
     "yzhang.markdown-all-in-one"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,8 @@
 {
-  "recommendations": ["denoland.vscode-deno"]
+  "recommendations": [
+    // https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno
+    "denoland.vscode-deno",
+    // https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
+    "yzhang.markdown-all-in-one"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "deno.enable": true,
   "deno.lint": true,
-  "deno.unstable": false
+  "deno.unstable": false,
+  "markdown.extension.toc.levels": "2..6"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,15 @@
 
 A guide on how to participate in this project.
 
-- [Contribute Guide](#contribute-guide)
-  - [Issues](#issues)
-  - [Pull Requests](#pull-requests)
-    - [Review](#review)
-  - [Commit Message](#commit-message)
-  - [Style Guide](#style-guide)
-    - [TypeScript](#typescript)
-      - [null and undefined](#null-and-undefined)
-      - [Quote marks](#quote-marks)
-      - [Arrays](#arrays)
+- [Issues](#issues)
+- [Pull Requests](#pull-requests)
+  - [Review](#review)
+- [Commit Message](#commit-message)
+- [Style Guide](#style-guide)
+  - [TypeScript](#typescript)
+    - [null and undefined](#null-and-undefined)
+    - [Quote marks](#quote-marks)
+    - [Arrays](#arrays)
 
 **Before "Contribution"**: All Contributors and Maintainers are required to follow the [Code of Conduct](./CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
## What does this PR do?

VSCode の拡張機能 [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one) をプロジェクト (Workspace) 規定のプラグインに指定しました.

## Additional information

Markdown All in One が自動生成する Toc (目次) の対象見出しレベルを `2` から `6` の間に変更しました.

これはファイルのタイトルが目次に挿入されてしまうのを防ぐためです.
