### PR TITLE
chore: renovate のセットアップ

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>pulsate-dev/renovate-conf"],
+  "reviewers": ["team:pulsate"],
+  "rollback": {
+    "additionalReviewers": ["m1sk9", "MikuroXina", "Colk-tech"]
+  },
+  "vulnerabilityAlerts": {
+    "additionalReviewers": ["m1sk9", "MikuroXina", "Colk-tech"]
+  }
+}


### PR DESCRIPTION
## What does this PR do?

[pulsate-dev/renovate-conf](https://github.com/approvers/pulsate) を適用し, renovate をセットアップします. 

なお, pulsate-dev/renovate-conf は pulsate-dev 依存の設定があり, それらは Overwrite しています.

## Additional information

renovate が Deno をネイティブサポートしていないため, 正規表現で依存関係マネージャーを設定できる `regexManagers` を使用し, Deno を無理やり対応させています.

1. 参考: [Renovate で Deno の依存関係を自動で更新する - blog.s2n.tech](https://blog.s2n.tech/articles/renovate-deno)
2. 参考: https://github.com/renovatebot/renovate/issues/6237