### PR TITLE
feat: add `SilenceService` and `FreezeService`

### DIFF
--- a/pkg/accounts/adaptor/repository/dummy.ts
+++ b/pkg/accounts/adaptor/repository/dummy.ts
@@ -16,6 +16,10 @@ export class InMemoryAccountRepository implements AccountRepository {
     return Promise.resolve(Result.ok(undefined));
   }
 
+  reset(): void {
+    this.data.clear();
+  }
+
   findByName(name: string): Promise<Option.Option<Account>> {
     const account = Array.from(this.data).find((a) => a.getName === name);
     if (!account) {

--- a/pkg/accounts/service/freeze_service.test.ts
+++ b/pkg/accounts/service/freeze_service.test.ts
@@ -1,0 +1,54 @@
+import { Result } from 'mini-fn';
+import { Clock, SnowflakeIDGenerator } from '../../id/mod.ts';
+import { ScryptPasswordEncoder } from '../../password/mod.ts';
+import { DummySendNotificationService } from './send_notification_service.ts';
+import {
+  InMemoryAccountRepository,
+  InMemoryAccountVerifyTokenRepository,
+} from '../adaptor/repository/dummy.ts';
+import { RegisterAccountService } from './register_service.ts';
+import { TokenVerifyService } from './token_verify_service.ts';
+import { AccountRole } from '../model/account.ts';
+import { assertEquals } from 'std/assert';
+import { FreezeService } from './freeze_service.ts';
+
+const repository = new InMemoryAccountRepository();
+const verifyRepository = new InMemoryAccountVerifyTokenRepository();
+class DummyClock implements Clock {
+  Now(): bigint {
+    return BigInt(new Date('2023/9/10 00:00:00 UTC').getTime());
+  }
+}
+const registerService: RegisterAccountService = new RegisterAccountService({
+  repository,
+  idGenerator: new SnowflakeIDGenerator(1, new DummyClock()),
+  passwordEncoder: new ScryptPasswordEncoder(),
+  sendNotification: new DummySendNotificationService(),
+  verifyTokenService: new TokenVerifyService(verifyRepository),
+});
+const freezeService = new FreezeService(repository);
+
+const exampleInput = {
+  name: 'john_doe@example.com',
+  mail: 'johndoe@example.com',
+  nickname: 'John Doe',
+  passphrase: 'password',
+  bio: 'Hello, World!',
+  role: 'normal' as AccountRole,
+};
+
+Deno.test('set account freeze', async () => {
+  const res = await registerService.handle(
+    exampleInput.name,
+    exampleInput.mail,
+    exampleInput.nickname,
+    exampleInput.passphrase,
+    exampleInput.bio,
+    exampleInput.role,
+  );
+  if (Result.isErr(res)) return;
+
+  await freezeService.setFreeze(exampleInput.name);
+
+  assertEquals(res[1].getFrozen, 'frozen');
+});

--- a/pkg/accounts/service/freeze_service.test.ts
+++ b/pkg/accounts/service/freeze_service.test.ts
@@ -9,7 +9,7 @@ import {
 import { RegisterAccountService } from './register_service.ts';
 import { TokenVerifyService } from './token_verify_service.ts';
 import { AccountRole } from '../model/account.ts';
-import { assertEquals } from 'std/assert';
+import { assertEquals, assertNotEquals } from 'std/assert';
 import { FreezeService } from './freeze_service.ts';
 
 const repository = new InMemoryAccountRepository();
@@ -51,4 +51,24 @@ Deno.test('set account freeze', async () => {
   await freezeService.setFreeze(exampleInput.name);
 
   assertEquals(res[1].getFrozen, 'frozen');
+  assertNotEquals(res[1].getFrozen, 'normal');
+  repository.reset();
+});
+
+Deno.test('unset account freeze', async () => {
+  const res = await registerService.handle(
+    exampleInput.name,
+    exampleInput.mail,
+    exampleInput.nickname,
+    exampleInput.passphrase,
+    exampleInput.bio,
+    exampleInput.role,
+  );
+  if (Result.isErr(res)) return;
+
+  await freezeService.undoFreeze(exampleInput.name);
+
+  assertEquals(res[1].getFrozen, 'normal');
+  assertNotEquals(res[1].getFrozen, 'frozen');
+  repository.reset();
 });

--- a/pkg/accounts/service/freeze_service.ts
+++ b/pkg/accounts/service/freeze_service.ts
@@ -21,4 +21,20 @@ export class FreezeService {
       return Result.err(e);
     }
   }
+
+  async undoFreeze(
+    accountName: string,
+  ): Promise<Result.Result<Error, boolean>> {
+    const account = await this.accountRepository.findByName(accountName);
+    if (Option.isNone(account)) {
+      return Result.err(new Error('account not found'));
+    }
+
+    try {
+      account[1].setUnfreeze();
+      return Result.ok(true);
+    } catch (e) {
+      return Result.err(e);
+    }
+  }
 }

--- a/pkg/accounts/service/freeze_service.ts
+++ b/pkg/accounts/service/freeze_service.ts
@@ -1,0 +1,24 @@
+import { Option, Result } from 'mini-fn';
+import { AccountRepository } from '../model/repository.ts';
+
+export class FreezeService {
+  private readonly accountRepository: AccountRepository;
+
+  constructor(accountRepository: AccountRepository) {
+    this.accountRepository = accountRepository;
+  }
+
+  async setFreeze(accountName: string): Promise<Result.Result<Error, boolean>> {
+    const account = await this.accountRepository.findByName(accountName);
+    if (Option.isNone(account)) {
+      return Result.err(new Error('account not found'));
+    }
+
+    try {
+      account[1].setFreeze();
+      return Result.ok(true);
+    } catch (e) {
+      return Result.err(e);
+    }
+  }
+}

--- a/pkg/accounts/service/register_service.test.ts
+++ b/pkg/accounts/service/register_service.test.ts
@@ -5,14 +5,13 @@ import {
   InMemoryAccountRepository,
   InMemoryAccountVerifyTokenRepository,
 } from '../adaptor/repository/dummy.ts';
-import { AccountRepository } from '../model/repository.ts';
 import { RegisterAccountService } from './register_service.ts';
 import { DummySendNotificationService } from './send_notification_service.ts';
 import { TokenVerifyService } from './token_verify_service.ts';
 import { Result } from 'mini-fn';
 import { AccountRole } from '../model/account.ts';
 
-const repository: AccountRepository = new InMemoryAccountRepository();
+const repository = new InMemoryAccountRepository();
 const verifyRepository = new InMemoryAccountVerifyTokenRepository();
 class DummyClock implements Clock {
   Now(): bigint {
@@ -50,8 +49,8 @@ Deno.test('register account', async () => {
   assertEquals(res[1].getName, exampleInput.name);
   assertEquals(res[1].getMail, exampleInput.mail);
   assertEquals(res[1].getNickname, exampleInput.nickname);
-  assertEquals(res[1].getPassphraseHash, exampleInput.passphrase);
   assertEquals(res[1].getBio, exampleInput.bio);
   assertEquals(res[1].getRole, exampleInput.role);
   assertEquals(res[1].getStatus, 'notActivated');
+  repository.reset();
 });

--- a/pkg/accounts/service/register_service.ts
+++ b/pkg/accounts/service/register_service.ts
@@ -93,10 +93,6 @@ export class RegisterAccountService {
     const byName = await this.accountRepository.findByName(name);
     const byMail = await this.accountRepository.findByMail(mail);
 
-    if (Option.isNone(byName) || Option.isNone(byMail)) {
-      return true;
-    }
-
-    return false;
+    return Option.isSome(byName) || Option.isSome(byMail);
   }
 }

--- a/pkg/accounts/service/silence_service.test.ts
+++ b/pkg/accounts/service/silence_service.test.ts
@@ -1,0 +1,71 @@
+import { Result } from 'mini-fn';
+import { Clock, SnowflakeIDGenerator } from '../../id/mod.ts';
+import { ScryptPasswordEncoder } from '../../password/mod.ts';
+import { DummySendNotificationService } from './send_notification_service.ts';
+import {
+  InMemoryAccountRepository,
+  InMemoryAccountVerifyTokenRepository,
+} from '../adaptor/repository/dummy.ts';
+import { RegisterAccountService } from './register_service.ts';
+import { TokenVerifyService } from './token_verify_service.ts';
+import { AccountRole } from '../model/account.ts';
+import { assertEquals } from 'std/assert';
+import { SilenceService } from './silence_service.ts';
+
+const repository = new InMemoryAccountRepository();
+const verifyRepository = new InMemoryAccountVerifyTokenRepository();
+class DummyClock implements Clock {
+  Now(): bigint {
+    return BigInt(new Date('2023/9/10 00:00:00 UTC').getTime());
+  }
+}
+const registerService: RegisterAccountService = new RegisterAccountService({
+  repository,
+  idGenerator: new SnowflakeIDGenerator(1, new DummyClock()),
+  passwordEncoder: new ScryptPasswordEncoder(),
+  sendNotification: new DummySendNotificationService(),
+  verifyTokenService: new TokenVerifyService(verifyRepository),
+});
+const silenceService = new SilenceService(repository);
+
+const exampleInput = {
+  name: 'john_doe@example.com',
+  mail: 'johndoe@example.com',
+  nickname: 'John Doe',
+  passphrase: 'password',
+  bio: 'Hello, World!',
+  role: 'normal' as AccountRole,
+};
+
+Deno.test('set account silence', async () => {
+  const res = await registerService.handle(
+    exampleInput.name,
+    exampleInput.mail,
+    exampleInput.nickname,
+    exampleInput.passphrase,
+    exampleInput.bio,
+    exampleInput.role,
+  );
+  if (Result.isErr(res)) return;
+
+  await silenceService.setSilence(exampleInput.name);
+
+  assertEquals(res[1].getSilenced, 'silenced');
+});
+
+Deno.test('unset account silence', async () => {
+  const res = await registerService.handle(
+    exampleInput.name,
+    exampleInput.mail,
+    exampleInput.nickname,
+    exampleInput.passphrase,
+    exampleInput.bio,
+    exampleInput.role,
+  );
+  if (Result.isErr(res)) return;
+
+  await silenceService.setSilence(exampleInput.name);
+  await silenceService.undoSilence(exampleInput.name);
+
+  assertEquals(res[1].getSilenced, 'normal');
+});

--- a/pkg/accounts/service/silence_service.test.ts
+++ b/pkg/accounts/service/silence_service.test.ts
@@ -9,7 +9,7 @@ import {
 import { RegisterAccountService } from './register_service.ts';
 import { TokenVerifyService } from './token_verify_service.ts';
 import { AccountRole } from '../model/account.ts';
-import { assertEquals } from 'std/assert';
+import { assertEquals, assertNotEquals } from 'std/assert';
 import { SilenceService } from './silence_service.ts';
 
 const repository = new InMemoryAccountRepository();
@@ -51,6 +51,8 @@ Deno.test('set account silence', async () => {
   await silenceService.setSilence(exampleInput.name);
 
   assertEquals(res[1].getSilenced, 'silenced');
+  assertNotEquals(res[1].getSilenced, 'normal');
+  repository.reset();
 });
 
 Deno.test('unset account silence', async () => {
@@ -68,4 +70,6 @@ Deno.test('unset account silence', async () => {
   await silenceService.undoSilence(exampleInput.name);
 
   assertEquals(res[1].getSilenced, 'normal');
+  assertNotEquals(res[1].getSilenced, 'silenced');
+  repository.reset();
 });

--- a/pkg/accounts/service/silence_service.ts
+++ b/pkg/accounts/service/silence_service.ts
@@ -1,0 +1,42 @@
+import { Option, Result } from 'mini-fn';
+import { AccountRepository } from '../model/repository.ts';
+
+export class SilenceService {
+  private readonly accountRepository: AccountRepository;
+
+  constructor(accountRepository: AccountRepository) {
+    this.accountRepository = accountRepository;
+  }
+
+  async setSilence(
+    accountName: string,
+  ): Promise<Result.Result<Error, boolean>> {
+    const account = await this.accountRepository.findByName(accountName);
+    if (Option.isNone(account)) {
+      return Result.err(new Error('account not found'));
+    }
+
+    try {
+      account[1].setSilence();
+      return Result.ok(true);
+    } catch (e) {
+      return Result.err(e);
+    }
+  }
+
+  async undoSilence(
+    accountName: string,
+  ): Promise<Result.Result<Error, boolean>> {
+    const account = await this.accountRepository.findByName(accountName);
+    if (Option.isNone(account)) {
+      return Result.err(new Error('account not found'));
+    }
+
+    try {
+      account[1].undoSilence();
+      return Result.ok(true);
+    } catch (e) {
+      return Result.err(e);
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Add `SilenceService` and `FreezeService`.

- `SilenceService` puts an account into silence. (Accounts under silencing will not be able to post, etc...)
- `FreezeService` puts an account into freeze. (Accounts that are frozen will not be able to access the Pulsate instance itself.)
https://github.com/approvers/pulsate/blob/9214614389258917896de85fe2a30bf6637394ab/docs/api.yaml#L148-L169